### PR TITLE
chore: Patch token2022 for new extensions support

### DIFF
--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "anchor-lang",
  "solana-program",
  "spl-associated-token-account",
- "spl-token",
+ "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022",
 ]
 
@@ -2006,7 +2006,7 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "solana-program",
- "spl-token",
+ "spl-token 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022",
  "thiserror",
 ]
@@ -2014,8 +2014,7 @@ dependencies = [
 [[package]]
 name = "spl-discriminator"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2025,8 +2024,7 @@ dependencies = [
 [[package]]
 name = "spl-discriminator-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
@@ -2036,8 +2034,7 @@ dependencies = [
 [[package]]
 name = "spl-discriminator-syn"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,8 +2046,7 @@ dependencies = [
 [[package]]
 name = "spl-memo"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "solana-program",
 ]
@@ -2058,8 +2054,7 @@ dependencies = [
 [[package]]
 name = "spl-pod"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
@@ -2071,8 +2066,7 @@ dependencies = [
 [[package]]
 name = "spl-program-error"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "num-derive 0.4.1",
  "num-traits",
@@ -2084,8 +2078,7 @@ dependencies = [
 [[package]]
 name = "spl-program-error-derive"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2096,8 +2089,7 @@ dependencies = [
 [[package]]
 name = "spl-tlv-account-resolution"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2123,10 +2115,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token"
+version = "4.0.0"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.1",
+ "num-traits",
+ "num_enum 0.7.1",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-token-2022"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2137,7 +2142,8 @@ dependencies = [
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
- "spl-token",
+ "spl-token 4.0.0 (git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d)",
+ "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
@@ -2145,10 +2151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-group-interface"
+version = "0.1.0"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+]
+
+[[package]]
 name = "spl-token-metadata-interface"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "borsh 0.10.3",
  "solana-program",
@@ -2161,8 +2178,7 @@ dependencies = [
 [[package]]
 name = "spl-transfer-hook-interface"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2177,8 +2193,7 @@ dependencies = [
 [[package]]
 name = "spl-type-length-value"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
+source = "git+https://github.com/solana-labs/solana-program-library.git?rev=0df0cba7f74a1b8b80e4d4383586c375c071a80d#0df0cba7f74a1b8b80e4d4383586c375c071a80d"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -11,3 +11,6 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+[patch.crates-io]
+spl-token-2022 = { git = "https://github.com/solana-labs/solana-program-library.git", rev = "0df0cba7f74a1b8b80e4d4383586c375c071a80d" }

--- a/program/package.json
+++ b/program/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.0",
-    "@solana/spl-token": "^0.3.9"
+    "@solana/spl-token": "^0.4.1"
   },
   "devDependencies": {
     "@coral-xyz/spl-token": "^0.28.0",

--- a/program/yarn.lock
+++ b/program/yarn.lock
@@ -86,13 +86,69 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-token@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.9.tgz#477e703c3638ffb17dd29b82a203c21c3e465851"
-  integrity sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==
+"@solana/codecs-core@2.0.0-experimental.8618508":
+  version "2.0.0-experimental.8618508"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-core/-/codecs-core-2.0.0-experimental.8618508.tgz#4f6709dd50e671267f3bea7d09209bc6471b7ad0"
+  integrity sha512-JCz7mKjVKtfZxkuDtwMAUgA7YvJcA2BwpZaA1NOLcted4OMC4Prwa3DUe3f3181ixPYaRyptbF0Ikq2MbDkYEA==
+
+"@solana/codecs-data-structures@2.0.0-experimental.8618508":
+  version "2.0.0-experimental.8618508"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-experimental.8618508.tgz#c16a704ac0f743a2e0bf73ada42d830b3402d848"
+  integrity sha512-sLpjL9sqzaDdkloBPV61Rht1tgaKq98BCtIKRuyscIrmVPu3wu0Bavk2n/QekmUzaTsj7K1pVSniM0YqCdnEBw==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-experimental.8618508"
+    "@solana/codecs-numbers" "2.0.0-experimental.8618508"
+
+"@solana/codecs-numbers@2.0.0-experimental.8618508":
+  version "2.0.0-experimental.8618508"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-numbers/-/codecs-numbers-2.0.0-experimental.8618508.tgz#d84f9ed0521b22e19125eefc7d51e217fcaeb3e4"
+  integrity sha512-EXQKfzFr3CkKKNzKSZPOOOzchXsFe90TVONWsSnVkonO9z+nGKALE0/L9uBmIFGgdzhhU9QQVFvxBMclIDJo2Q==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-experimental.8618508"
+
+"@solana/codecs-strings@2.0.0-experimental.8618508":
+  version "2.0.0-experimental.8618508"
+  resolved "https://registry.yarnpkg.com/@solana/codecs-strings/-/codecs-strings-2.0.0-experimental.8618508.tgz#72457b884d9be80b59b263bcce73892b081e9402"
+  integrity sha512-b2yhinr1+oe+JDmnnsV0641KQqqDG8AQ16Z/x7GVWO+AWHMpRlHWVXOq8U1yhPMA4VXxl7i+D+C6ql0VGFp0GA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-experimental.8618508"
+    "@solana/codecs-numbers" "2.0.0-experimental.8618508"
+
+"@solana/options@2.0.0-experimental.8618508":
+  version "2.0.0-experimental.8618508"
+  resolved "https://registry.yarnpkg.com/@solana/options/-/options-2.0.0-experimental.8618508.tgz#95385340e85f9e8a81b2bfba089404a61c8e9520"
+  integrity sha512-fy/nIRAMC3QHvnKi63KEd86Xr/zFBVxNW4nEpVEU2OT0gCEKwHY4Z55YHf7XujhyuM3PNpiBKg/YYw5QlRU4vg==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-experimental.8618508"
+    "@solana/codecs-numbers" "2.0.0-experimental.8618508"
+
+"@solana/spl-token-metadata@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token-metadata/-/spl-token-metadata-0.1.2.tgz#876e13432bd2960bd3cac16b9b0af63e69e37719"
+  integrity sha512-hJYnAJNkDrtkE2Q41YZhCpeOGU/0JgRFXbtrtOuGGeKc3pkEUHB9DDoxZAxx+XRno13GozUleyBi0qypz4c3bw==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-experimental.8618508"
+    "@solana/codecs-data-structures" "2.0.0-experimental.8618508"
+    "@solana/codecs-numbers" "2.0.0-experimental.8618508"
+    "@solana/codecs-strings" "2.0.0-experimental.8618508"
+    "@solana/options" "2.0.0-experimental.8618508"
+    "@solana/spl-type-length-value" "0.1.0"
+
+"@solana/spl-token@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.1.tgz#7302c8052803f63012bd8189d42ca7d74d7917a5"
+  integrity sha512-DEe15GI0l+XLHwtau/3GUwGQJ9YY/VWNE0k/QuXaaGKo4adMZLEAIQUktRc/S2sRqPjvUdR5anZGxQ9p5khWZw==
   dependencies:
     "@solana/buffer-layout" "^4.0.0"
     "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-metadata" "^0.1.2"
+    buffer "^6.0.3"
+
+"@solana/spl-type-length-value@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz#b5930cf6c6d8f50c7ff2a70463728a4637a2f26b"
+  integrity sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==
+  dependencies:
     buffer "^6.0.3"
 
 "@solana/web3.js@^1.32.0":


### PR DESCRIPTION
Problem: To init a token account we need all new extensions on its mint to be deserializable.
New extensions aren't and fail.

This is a known issue but anchor-spl cannot bump it yet https://github.com/coral-xyz/anchor/pull/2802

Patch to group pointer commit on 0.9.0 so that we should be able to deserialize all recent extensions