### PR TITLE
Support optional custom RPC URL in FeeService class

### DIFF
--- a/packages/sdk/src/FeeService.ts
+++ b/packages/sdk/src/FeeService.ts
@@ -50,6 +50,7 @@ interface GetOptimalComputeUnitLimitAndPriceResponse {
 interface FeeService {
   getOptimalComputeUnitLimitAndPrice: (
     payload: GetOptimalComputeUnitLimitAndPricePayload,
+    connection?: Connection
   ) => Promise<GetOptimalComputeUnitLimitAndPriceResponse>;
 }
 
@@ -84,6 +85,7 @@ class FeeServiceImpl implements FeeService {
    */
   private getSimulationUnits = async (
     payload: GetOptimalComputeUnitLimitAndPricePayload,
+    connection?: Connection
   ) => {
     const { instructions, payer, lookupTables } = payload;
 
@@ -100,7 +102,7 @@ class FeeServiceImpl implements FeeService {
       }).compileToV0Message(lookupTables),
     );
 
-    const simulation = await this.connection.simulateTransaction(
+    const simulation = await (connection || this.connection).simulateTransaction(
       testVersionedTxn,
       {
         replaceRecentBlockhash: true,
@@ -125,9 +127,9 @@ class FeeServiceImpl implements FeeService {
   // Main methods
   // --------------------
   getOptimalComputeUnitLimitAndPrice: FeeService["getOptimalComputeUnitLimitAndPrice"] =
-    async (payload) => {
+    async (payload, connection?: Connection) => {
       // Unit
-      const simulationUnits = await this.getSimulationUnits(payload);
+      const simulationUnits = await this.getSimulationUnits(payload, connection);
       /**
        * Best practices to always add a margin error to the simulation units (10% ~ 20%)
        * @see https://solana.com/developers/guides/advanced/how-to-request-optimal-compute#special-considerations

--- a/packages/sdk/src/referral.ts
+++ b/packages/sdk/src/referral.ts
@@ -530,7 +530,7 @@ export class ReferralProvider {
         instructions: transaction.instructions,
         payer: payerPubKey,
         lookupTables: [lookupTableAccount],
-      });
+      }, this.connection);
     instructions.unshift(
       ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
     );
@@ -571,9 +571,9 @@ export class ReferralProvider {
 
     const { tokenAccounts, token2022Accounts } = strategy
       ? await this.getReferralTokenAccountsWithStrategy(
-          referralAccountPubKey.toString(),
-          strategy,
-        )
+        referralAccountPubKey.toString(),
+        strategy,
+      )
       : await this.getReferralTokenAccounts(referralAccountPubKey.toString());
 
     const vtTxs = await Promise.all(
@@ -677,7 +677,7 @@ export class ReferralProvider {
                 instructions,
                 payer: payerPubKey,
                 lookupTables: [lookupTableAccount],
-              });
+              }, this.connection);
             instructions.unshift(
               ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
             );
@@ -834,7 +834,7 @@ export class ReferralProvider {
             instructions,
             payer: payerPubKey,
             lookupTables: [lookupTableAccount],
-          });
+          }, this.connection);
         instructions.unshift(
           ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
         );


### PR DESCRIPTION
The existing code uses the `RPC_URL` constant defined in the `constant.ts` file to instantiate a new web3 connection.

With these changes, a `Connection` can be optionally passed to the `getOptimalComputeUnitLimitAndPrice` function, which is used to override the connection defined in the constructor of the FeeService class when `Connection.simulateTransaction` is executed.

Additionally, inside the referral.ts file, the referral provider's connection property is passed to `feeService.getOptimalComputeUnitLimitAndPrice` to ensure that the fee service can make use of custom RPC URLs passed to the provider.